### PR TITLE
Fix images in sub directories

### DIFF
--- a/image_derive_all.drush.inc
+++ b/image_derive_all.drush.inc
@@ -102,8 +102,7 @@ function image_derive_all_get_relevant_files($directory) {
 
   $dir = rtrim($directory, '/');
   if ($dir == 'public') {
-    // Finds anything that does not contain "/", should be fine.
-    $file_pattern = "[^\/]*";
+    $file_pattern = ".*";
   }
   else {
     $file_pattern = $dir ? $dir . ".+" : ".+";


### PR DESCRIPTION
Fix creating image derivatives for images in sub-directories of the public directory - for example when URIs are like `public://2016-05/picjumbo.com_HNCK7731.jpg` - putting images in sub directories is drupal core's default behaviour.